### PR TITLE
Clean orphaned child processes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,6 @@ build:
 lint:
 	golangci-lint run
 
-.PHONY: publish
-publish:
-	okteto build -t okteto/supervisor:0.1.0 .
+.PHONY: push
+push:
+	okteto build -t okteto/supervisor:0.1.1 .

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,11 +3,13 @@ package main
 import (
 	"context"
 	"flag"
-	"github.com/okteto/supervisor/pkg/monitor"
-	log "github.com/sirupsen/logrus"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/okteto/supervisor/pkg/monitor"
+	reaper "github.com/ramr/go-reaper"
+	log "github.com/sirupsen/logrus"
 )
 
 // CommitString is the commit used to build the server
@@ -15,6 +17,9 @@ var CommitString string
 
 func main() {
 	log.WithField("commit", CommitString).Infof("supervisor started")
+
+	//  Start background reaping of orphaned child processes.
+	reaper.Reap()
 
 	remoteFlag := flag.Bool("remote", false, "start the remote server")
 	flag.Parse()

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.13
 
 require (
 	github.com/go-cmd/cmd v1.1.0
+	github.com/ramr/go-reaper v0.2.0
 	github.com/sirupsen/logrus v1.4.2
 )

--- a/go.sum
+++ b/go.sum
@@ -2,11 +2,14 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-cmd/cmd v1.1.0 h1:LxXflJCRKNZgoKl/0TJdzIDSGFdik3zxaeyL1yXCTsI=
 github.com/go-cmd/cmd v1.1.0/go.mod h1:bkfdaV0aMvVwTINGdkU5jlQEd9gF0z4irQutl37pOd8=
+github.com/go-test/deep v1.0.1 h1:UQhStjbkDClarlmv0am7OXXO4/GaPdCGiUiMTvi28sg=
 github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/ramr/go-reaper v0.2.0 h1:hhGZ1SRZ9fJfSEf9e14hRB4O0MafRwHK5O33j70qTNI=
+github.com/ramr/go-reaper v0.2.0/go.mod h1:DFg2AhfQCvkJwRKUfsycOSSZELGBA9gt46ne3SOecJM=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/okteto.yml
+++ b/okteto.yml
@@ -13,3 +13,5 @@ securityContext:
 forward:
 - 8080:8080
 - 2345:2345
+persistentVolume:
+  enabled: true


### PR DESCRIPTION
Based on https://github.com/ramr/go-reaper

Orphaned child processes are adopted by the `init` process (our supervisor) and then reaped by this library