### PR TITLE
Ensure process and its children are gone before restarting a process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # supervisor
-process supervisor for okteto
+
+Process supervisor for okteto

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,7 @@ go 1.14
 require (
 	github.com/go-cmd/cmd v1.1.0
 	github.com/ramr/go-reaper v0.2.0
+	github.com/shirou/gopsutil v3.21.2+incompatible
 	github.com/sirupsen/logrus v1.4.2
+	github.com/tklauser/go-sysconf v0.3.5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,10 +10,17 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/ramr/go-reaper v0.2.0 h1:hhGZ1SRZ9fJfSEf9e14hRB4O0MafRwHK5O33j70qTNI=
 github.com/ramr/go-reaper v0.2.0/go.mod h1:DFg2AhfQCvkJwRKUfsycOSSZELGBA9gt46ne3SOecJM=
+github.com/shirou/gopsutil v3.21.2+incompatible h1:U+YvJfjCh6MslYlIAXvPtzhW3YZEtc9uncueUNpD/0A=
+github.com/shirou/gopsutil v3.21.2+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/tklauser/go-sysconf v0.3.5 h1:uu3Xl4nkLzQfXNsWn15rPc/HQCJKObbt1dKJeWp3vU4=
+github.com/tklauser/go-sysconf v0.3.5/go.mod h1:MkWzOF4RMCshBAMXuhXJs64Rte09mITnppBXY/rYEFI=
+github.com/tklauser/numcpus v0.2.2/go.mod h1:x3qojaO3uyYt0i56EW/VUYs7uBvdl2fkfZFu0T9wgjM=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210316164454-77fc1eacc6aa h1:ZYxPR6aca/uhfRJyaOAtflSHjJYiktO7QnJC5ut7iY4=
+golang.org/x/sys v0.0.0-20210316164454-77fc1eacc6aa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -76,6 +76,8 @@ func (m *Monitor) checkState(p *Process, wg *sync.WaitGroup) {
 			return
 		}
 
+		p.killAllByName()
+
 		log.Infof("Restarting process %s", p.Name)
 		p.start()
 	case fatal:
@@ -83,6 +85,8 @@ func (m *Monitor) checkState(p *Process, wg *sync.WaitGroup) {
 			m.err <- fmt.Errorf("%s started %d times", p.Name, p.startCount)
 			return
 		}
+
+		p.killAllByName()
 
 		log.Errorf("Restarting process %s after failure", p.Name)
 		p.start()


### PR DESCRIPTION
This solves an issue where there is a connection glitch, synthing stops because it is not making any progress, and it cannot restart anymore because the previous process/children was not completely gone:

```
time="2021-03-19T10:21:30Z" level=info msg="[ATOPH] 10:21:29 INFO: \"1\" (okteto-1): Failed to sync 268 items" process=syncthing
time="2021-03-19T10:21:30Z" level=info msg="[ATOPH] 10:21:29 INFO: Folder \"1\" (okteto-1) isn't making sync progress - retrying in 1m1s." process=syncthing
time="2021-03-19T10:21:37Z" level=error msg="process exited with error status 0" error="wait: no child processes" process=syncthing
time="2021-03-19T10:21:37Z" level=error msg="Restarting process syncthing after failure"
time="2021-03-19T10:21:37Z" level=info msg="starting /var/okteto/bin/syncthing -home /var/syncthing -gui-address 0.0.0.0:8384 -verbose" process=syncthing
time="2021-03-19T10:21:37Z" level=info msg="[start] 10:21:37 INFO: syncthing v1.14.0 \"Fermium Flea\" (go1.16 linux-amd64) docker@build.syncthing.net 2021-02-26 12:21:13 UTC [noupgrade]" process=syncthing
time="2021-03-19T10:21:37Z" level=info msg="[start] 10:21:37 WARNING: Error opening database: resource temporarily unavailable (is another instance of Syncthing running?)" process=syncthing
```