### PR TITLE
Reset syncthing database after syncthing failures

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -35,7 +35,7 @@ func main() {
 	}()
 
 	if *resetFlag {
-		cmd := exec.Command("/var/okteto/bin/syncthing", "-home", "/var/syncthing", "-reset-database")
+		cmd := exec.Command(monitor.SyncthingBin, "-home", "/var/syncthing", "-reset-database")
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			log.WithError(err).Errorf("error resetting syncthing database: %s", output)
@@ -45,8 +45,8 @@ func main() {
 	m := monitor.NewMonitor(ctx)
 	m.Add(monitor.NewProcess(
 		"syncthing",
-		"/var/okteto/bin/syncthing",
-		[]string{"-home", "/var/syncthing", "-gui-address", "0.0.0.0:8384", "-verbose", "-reset-deltas"}),
+		monitor.SyncthingBin,
+		[]string{"-home", "/var/syncthing", "-gui-address", "0.0.0.0:8384", "-verbose"}),
 	)
 
 	if *remoteFlag {

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -3,6 +3,7 @@ package monitor
 import (
 	"context"
 	"fmt"
+	"os/exec"
 	"sync"
 	"time"
 
@@ -87,6 +88,17 @@ func (m *Monitor) checkState(p *Process, wg *sync.WaitGroup) {
 		}
 
 		p.killAllByName()
+
+		if p.Path == SyncthingBin {
+			log.Info("Resetting syncthing database after error...")
+			cmd := exec.Command(SyncthingBin, "-home", "/var/syncthing", "-reset-database")
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				log.WithError(err).Errorf("error resetting syncthing database: %s", output)
+			} else {
+				log.Infof("syncthing database reset: %s", output)
+			}
+		}
 
 		log.Errorf("Restarting process %s after failure", p.Name)
 		p.start()

--- a/pkg/monitor/process.go
+++ b/pkg/monitor/process.go
@@ -20,6 +20,8 @@ const (
 	stopping     state = "stopping"
 	stopped      state = "stopped"
 	fatal        state = "fatal"
+	//SyncthingBin path of the syncthing binary
+	SyncthingBin = "/var/okteto/bin/syncthing"
 )
 
 // Process is process monitored


### PR DESCRIPTION
After more tests, seems like a full reset is more reliable than a `-reset-deltas`.
This PR force a full reset syncthing database if syncthing exits with an error.