### PR TITLE
Update Dockerfile base images to Go 1.22.9 and Busybox 1.37.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-bookworm AS builder
+FROM golang:1.23.3-bookworm AS builder
 
 WORKDIR /app
 
@@ -13,7 +13,7 @@ ARG COMMIT_SHA
 
 RUN make
 
-FROM busybox
+FROM busybox:1.37.0
 
 COPY --from=builder /app/supervisor /usr/local/bin/supervisor
 RUN chmod +x /usr/local/bin/supervisor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.3-bookworm AS builder
+FROM golang:1.22.9-bookworm AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
Upgrade the base images in the Dockerfile to the latest versions of Go and Busybox for improved performance and security.